### PR TITLE
Refunds documentation for Python library

### DIFF
--- a/source/api/refunds.md.erb
+++ b/source/api/refunds.md.erb
@@ -5,11 +5,9 @@ title: Refunds
 ## Table of Contents
 
   - [The refund object](#the-refund-object)
-  - [Is a charge refundable?](#is-a-charge-refundable?)
   - [List refunds](#list-refunds)
   - [Create a refund](#create-a-refund)
   - [Retrieve a refund](#retrieve-a-refund)
-
 
 ---
 

--- a/source/api/refunds/create.md
+++ b/source/api/refunds/create.md
@@ -37,6 +37,13 @@ charge = Omise::Charge.retrieve("chrg_test_4xso2s8ivdej29pqnhz")
 refund = charge.refunds.create(amount: 10000)
 ```
 
+### Python
+
+```python
+charge = omise.Charge.retrieve("chrg_test_4xso2s8ivdej29pqnhz")
+refund = charge.refund(amount=10000)
+```
+
 ### JSON Response
 
 ```json

--- a/source/api/refunds/list.md
+++ b/source/api/refunds/list.md
@@ -28,6 +28,13 @@ charge = Omise::Charge.retrieve("chrg_test_4xso2s8ivdej29pqnhz")
 refunds = charge.refunds
 ```
 
+### Python
+
+```python
+charge = omise.Charge.retrieve("chrg_test_4xso2s8ivdej29pqnhz")
+refunds = charge.refunds
+```
+
 ### JSON Response
 
 ```json

--- a/source/api/refunds/retrieve.md
+++ b/source/api/refunds/retrieve.md
@@ -20,6 +20,13 @@ charge = Omise::Charge.retrieve("chrg_test_4xso2s8ivdej29pqnhz")
 refund = charge.refunds.retrieve("rfnd_test_4ypebtxon6oye5o8myu")
 ```
 
+### Python
+
+```python
+charge = omise.Charge.retrieve("chrg_test_4xso2s8ivdej29pqnhz")
+refund = charge.refunds.retrieve("rfnd_test_4ypebtxon6oye5o8myu")
+```
+
 ### JSON Response
 
 ```json


### PR DESCRIPTION
This pull request adds examples for refund API for Python library. Also I've noticed there's an extra entry on refunds TOC and removed accordingly in this branch.