### PR TITLE
[PENDING]Rake task to build the json object representations based on actual API calls

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,8 +64,8 @@ task :build_objects do
   puts "Make sure there is no error".center(80, " ")
   pkey = ENV["pkey"]
   skey = ENV["skey"]
-  puts "ENV['pkey']          -> #{ENV['pkey'].nil? ? 'MISSING' : 'Success'}"
-  puts "ENV['skey']          -> #{ENV['skey'].nil? ? 'MISSING' : 'Success'}"
+  puts "ENV['pkey']          -> #{ENV['pkey'].nil? ? 'ERROR! Make sure it is set.' : 'Success'}"
+  puts "ENV['skey']          -> #{ENV['skey'].nil? ? 'ERROR! Make sure it is set.' : 'Success'}"
   requests_path = "source/object_representations/requests/"
   responses = Hash.new({})
   Dir.glob("#{requests_path}*.sh").sort.each do |path|
@@ -82,13 +82,13 @@ task :build_objects do
     object_type = path[(requests_path.length+3)..(path_length-4)]
     if object_type == response["object"]
       puts "#{object_type.ljust(20)} -> Success"
+      File.open("source/api/#{object_type}s/_response.json", "w") do |file|
+        file.puts(JSON.pretty_generate(response))
+      end
     else
       puts "#{object_type.ljust(20)} -> ERROR! Check source/api/#{object_type}s/_response.json"
     end
     responses[object_type] = response
-    File.open("source/api/#{object_type}s/_response.json", "w") do |file|
-      file.puts(JSON.pretty_generate(response))
-    end
   end
   puts "DONE".center(80, "=")
 end

--- a/source/api/accounts/_response.json
+++ b/source/api/accounts/_response.json
@@ -1,6 +1,6 @@
 {
   "object": "account",
-  "id": "acct_4xs8bre8a8vhrgijcjg",
-  "email": null,
-  "created": "2014-10-20T08:21:42Z"
+  "id": "acct_4x7d2wtqnj2f4klrfsc",
+  "email": "gedeon@gedeon.be",
+  "created": "2014-08-27T23:53:52Z"
 }

--- a/source/api/balances/_response.json
+++ b/source/api/balances/_response.json
@@ -2,6 +2,6 @@
   "object": "balance",
   "livemode": false,
   "available": 0,
-  "total": 0,
+  "total": 2514008,
   "currency": "thb"
 }

--- a/source/api/balances/_response.json
+++ b/source/api/balances/_response.json
@@ -2,6 +2,6 @@
   "object": "balance",
   "livemode": false,
   "available": 0,
-  "total": 2514008,
+  "total": 2742290,
   "currency": "thb"
 }

--- a/source/api/cards/_response.json
+++ b/source/api/cards/_response.json
@@ -1,17 +1,18 @@
 {
   "object": "card",
-  "id": "card_test_4xsjw0t21xaxnuzi9gs",
+  "id": "card_test_4z9f62wadvhqp345zal",
   "livemode": false,
-  "location": "/customers/cust_test_4xsjvylia03ur542vn6/cards/card_test_4xsjw0t21xaxnuzi9gs",
-  "country": "",
+  "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards/card_test_4z9f62wadvhqp345zal",
+  "country": "us",
   "city": "Bangkok",
   "postal_code": "10320",
   "financing": "",
   "last_digits": "4242",
   "brand": "Visa",
   "expiration_month": 10,
-  "expiration_year": 2016,
-  "fingerprint": "uBNb5Z5J6firoMoDo80jEc1X/QucKQ4SCu80kP9U0gE=",
+  "expiration_year": 2018,
+  "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
   "name": "Somchai Prasert",
-  "created": "2014-10-21T04:04:12Z"
+  "security_code_check": true,
+  "created": "2015-03-05T08:07:19Z"
 }

--- a/source/api/cards/_response.json
+++ b/source/api/cards/_response.json
@@ -1,8 +1,8 @@
 {
   "object": "card",
-  "id": "card_test_4z9f62wadvhqp345zal",
+  "id": "card_test_4z9prs97rrpg11nxcps",
   "livemode": false,
-  "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards/card_test_4z9f62wadvhqp345zal",
+  "location": "/customers/cust_test_4z9psbuhupqxux0gt3n/cards/card_test_4z9prs97rrpg11nxcps",
   "country": "us",
   "city": "Bangkok",
   "postal_code": "10320",
@@ -14,5 +14,5 @@
   "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
   "name": "Somchai Prasert",
   "security_code_check": true,
-  "created": "2015-03-05T08:07:19Z"
+  "created": "2015-03-06T02:11:38Z"
 }

--- a/source/api/charges/_response.json
+++ b/source/api/charges/_response.json
@@ -1,35 +1,35 @@
 {
   "object": "charge",
-  "id": "chrg_test_4z9f5jww40wjr3bmsqp",
+  "id": "chrg_test_4z9psc1ximo7bppx7hu",
   "livemode": false,
-  "location": "/charges/chrg_test_4z9f5jww40wjr3bmsqp",
+  "location": "/charges/chrg_test_4z9psc1ximo7bppx7hu",
   "amount": 100000,
   "currency": "thb",
   "description": null,
   "capture": true,
   "authorized": true,
   "captured": true,
-  "transaction": "trxn_test_4z9f5jx7acbtbp5pvih",
+  "transaction": "trxn_test_4z9psc2bsw6cbh2nhql",
   "refunded": 0,
   "refunds": {
     "object": "list",
     "from": "1970-01-01T00:00:00+00:00",
-    "to": "2015-03-05T08:05:49+00:00",
+    "to": "2015-03-06T02:13:12+00:00",
     "offset": 0,
     "limit": 20,
     "total": 0,
     "data": [
 
     ],
-    "location": "/charges/chrg_test_4z9f5jww40wjr3bmsqp/refunds"
+    "location": "/charges/chrg_test_4z9psc1ximo7bppx7hu/refunds"
   },
   "failure_code": null,
   "failure_message": null,
   "card": {
     "object": "card",
-    "id": "card_test_4z9f62wadvhqp345zal",
+    "id": "card_test_4z9prs97rrpg11nxcps",
     "livemode": false,
-    "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards/card_test_4z9f62wadvhqp345zal",
+    "location": "/customers/cust_test_4z9psbuhupqxux0gt3n/cards/card_test_4z9prs97rrpg11nxcps",
     "country": "us",
     "city": "Bangkok",
     "postal_code": "10320",
@@ -41,9 +41,9 @@
     "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
     "name": "Somchai Prasert",
     "security_code_check": true,
-    "created": "2015-03-05T08:07:19Z"
+    "created": "2015-03-06T02:11:38Z"
   },
-  "customer": "cust_test_4z9f5jq2aswjsnlzm7v",
+  "customer": "cust_test_4z9psbuhupqxux0gt3n",
   "ip": null,
-  "created": "2015-03-05T08:05:49Z"
+  "created": "2015-03-06T02:13:12Z"
 }

--- a/source/api/charges/_response.json
+++ b/source/api/charges/_response.json
@@ -1,32 +1,49 @@
 {
   "object": "charge",
-  "id": "chrg_test_4xso2s8ivdej29pqnhz",
+  "id": "chrg_test_4z9f5jww40wjr3bmsqp",
   "livemode": false,
-  "location": "/charges/chrg_test_4xso2s8ivdej29pqnhz",
+  "location": "/charges/chrg_test_4z9f5jww40wjr3bmsqp",
   "amount": 100000,
   "currency": "thb",
-  "description": "Order-384",
+  "description": null,
   "capture": true,
-  "authorized": false,
-  "captured": false,
-  "transaction": null,
+  "authorized": true,
+  "captured": true,
+  "transaction": "trxn_test_4z9f5jx7acbtbp5pvih",
+  "refunded": 0,
+  "refunds": {
+    "object": "list",
+    "from": "1970-01-01T00:00:00+00:00",
+    "to": "2015-03-05T08:05:49+00:00",
+    "offset": 0,
+    "limit": 20,
+    "total": 0,
+    "data": [
+
+    ],
+    "location": "/charges/chrg_test_4z9f5jww40wjr3bmsqp/refunds"
+  },
+  "failure_code": null,
+  "failure_message": null,
   "card": {
     "object": "card",
-    "id": "card_test_4xs94086bpvq56tghuo",
+    "id": "card_test_4z9f62wadvhqp345zal",
     "livemode": false,
-    "country": "th",
+    "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards/card_test_4z9f62wadvhqp345zal",
+    "country": "us",
     "city": "Bangkok",
     "postal_code": "10320",
-    "financing": "credit",
+    "financing": "",
     "last_digits": "4242",
     "brand": "Visa",
     "expiration_month": 10,
     "expiration_year": 2018,
-    "fingerprint": "/LCaOoTah/+As+qKsohIldZkEfew0Zq2nJKgIObRwMI=",
+    "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
     "name": "Somchai Prasert",
-    "created": "2014-10-20T09:41:56Z"
+    "security_code_check": true,
+    "created": "2015-03-05T08:07:19Z"
   },
-  "customer": null,
-  "ip": "127.0.0.1",
-  "created": "2014-10-21T11:12:28Z"
+  "customer": "cust_test_4z9f5jq2aswjsnlzm7v",
+  "ip": null,
+  "created": "2015-03-05T08:05:49Z"
 }

--- a/source/api/customers/_response.json
+++ b/source/api/customers/_response.json
@@ -1,38 +1,39 @@
 {
   "object": "customer",
-  "id": "cust_test_4xtrb759599jsxlhkrb",
+  "id": "cust_test_4z9f5jq2aswjsnlzm7v",
   "livemode": false,
-  "location": "/customers/cust_test_4xtrb759599jsxlhkrb",
-  "default_card": "card_test_4xtsoy2nbfs7ujngyyq",
+  "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v",
+  "default_card": "card_test_4z9f62wadvhqp345zal",
   "email": "john.doe@example.com",
   "description": "John Doe (id: 30)",
-  "created": "2014-10-24T08:26:46Z",
+  "created": "2015-03-05T08:05:48Z",
   "cards": {
     "object": "list",
-    "from": "1970-01-01T07:00:00+07:00",
-    "to": "2014-10-24T15:32:31+07:00",
+    "from": "1970-01-01T00:00:00+00:00",
+    "to": "2015-03-05T08:05:48+00:00",
     "offset": 0,
     "limit": 20,
     "total": 1,
     "data": [
       {
         "object": "card",
-        "id": "card_test_4xtsoy2nbfs7ujngyyq",
+        "id": "card_test_4z9f62wadvhqp345zal",
         "livemode": false,
-        "location": "/customers/cust_test_4xtrb759599jsxlhkrb/cards/card_test_4xtsoy2nbfs7ujngyyq",
-        "country": "",
-        "city": null,
-        "postal_code": null,
+        "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards/card_test_4z9f62wadvhqp345zal",
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
         "financing": "",
         "last_digits": "4242",
         "brand": "Visa",
-        "expiration_month": 9,
-        "expiration_year": 2017,
-        "fingerprint": "q/kfc3jaZvlxIDobDQvziA4RSNdDdfXz9aFbXSjva8A=",
-        "name": "Test card",
-        "created": "2014-10-24T08:26:07Z"
+        "expiration_month": 10,
+        "expiration_year": 2018,
+        "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
+        "name": "Somchai Prasert",
+        "security_code_check": true,
+        "created": "2015-03-05T08:07:19Z"
       }
     ],
-    "location": "/customers/cust_test_4xtrb759599jsxlhkrb/cards"
+    "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards"
   }
 }

--- a/source/api/customers/_response.json
+++ b/source/api/customers/_response.json
@@ -1,25 +1,25 @@
 {
   "object": "customer",
-  "id": "cust_test_4z9f5jq2aswjsnlzm7v",
+  "id": "cust_test_4z9psbuhupqxux0gt3n",
   "livemode": false,
-  "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v",
-  "default_card": "card_test_4z9f62wadvhqp345zal",
+  "location": "/customers/cust_test_4z9psbuhupqxux0gt3n",
+  "default_card": "card_test_4z9prs97rrpg11nxcps",
   "email": "john.doe@example.com",
   "description": "John Doe (id: 30)",
-  "created": "2015-03-05T08:05:48Z",
+  "created": "2015-03-06T02:13:11Z",
   "cards": {
     "object": "list",
     "from": "1970-01-01T00:00:00+00:00",
-    "to": "2015-03-05T08:05:48+00:00",
+    "to": "2015-03-06T02:13:11+00:00",
     "offset": 0,
     "limit": 20,
     "total": 1,
     "data": [
       {
         "object": "card",
-        "id": "card_test_4z9f62wadvhqp345zal",
+        "id": "card_test_4z9prs97rrpg11nxcps",
         "livemode": false,
-        "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards/card_test_4z9f62wadvhqp345zal",
+        "location": "/customers/cust_test_4z9psbuhupqxux0gt3n/cards/card_test_4z9prs97rrpg11nxcps",
         "country": "us",
         "city": "Bangkok",
         "postal_code": "10320",
@@ -31,9 +31,9 @@
         "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
         "name": "Somchai Prasert",
         "security_code_check": true,
-        "created": "2015-03-05T08:07:19Z"
+        "created": "2015-03-06T02:11:38Z"
       }
     ],
-    "location": "/customers/cust_test_4z9f5jq2aswjsnlzm7v/cards"
+    "location": "/customers/cust_test_4z9psbuhupqxux0gt3n/cards"
   }
 }

--- a/source/api/refunds/_response.json
+++ b/source/api/refunds/_response.json
@@ -1,10 +1,10 @@
 {
   "object": "refund",
-  "id": "rfnd_test_4z9f63arl7z65uv1lh1",
-  "location": "/charges/chrg_test_4z9f5jww40wjr3bmsqp/refunds/rfnd_test_4z9f63arl7z65uv1lh1",
+  "id": "rfnd_test_4z9prsoukqoaniof8nu",
+  "location": "/charges/chrg_test_4z9psc1ximo7bppx7hu/refunds/rfnd_test_4z9prsoukqoaniof8nu",
   "amount": 20000,
   "currency": "thb",
-  "charge": "chrg_test_4z9f5jww40wjr3bmsqp",
-  "transaction": "trxn_test_4z9f63b0lipmoyk9ph1",
-  "created": "2015-03-05T08:07:20Z"
+  "charge": "chrg_test_4z9psc1ximo7bppx7hu",
+  "transaction": "trxn_test_4z9prsp0uis1skurwzk",
+  "created": "2015-03-06T02:11:40Z"
 }

--- a/source/api/refunds/_response.json
+++ b/source/api/refunds/_response.json
@@ -1,10 +1,10 @@
 {
   "object": "refund",
-  "id": "rfnd_test_4ypebtxon6oye5o8myu",
-  "livemode": false,
-  "location": "/charges/chrg_test_4ype2jynk2len88i4er/refunds/rfnd_test_4ypebtxon6oye5o8myu",
-  "amount": 100000,
+  "id": "rfnd_test_4z9f63arl7z65uv1lh1",
+  "location": "/charges/chrg_test_4z9f5jww40wjr3bmsqp/refunds/rfnd_test_4z9f63arl7z65uv1lh1",
+  "amount": 20000,
   "currency": "thb",
-  "charge": "chrg_test_4ype2jynk2len88i4er",
-  "created": "2015-01-13T03:28:58Z"
+  "charge": "chrg_test_4z9f5jww40wjr3bmsqp",
+  "transaction": "trxn_test_4z9f63b0lipmoyk9ph1",
+  "created": "2015-03-05T08:07:20Z"
 }

--- a/source/api/refunds/create/_create.sh
+++ b/source/api/refunds/create/_create.sh
@@ -1,4 +1,5 @@
-curl http://api.omise.co/charges/chrg_test_4ype2jynk2len88i4er/refunds \
+#!/bin/sh
+curl https://api.omise.co/charges/chrg_test_4ype2jynk2len88i4er/refunds \
   -X POST \
   -u skey_test_4ypcvnwzy9ob6gs89pn: \
   -d "amount=100000"

--- a/source/api/tokens/_response.json
+++ b/source/api/tokens/_response.json
@@ -1,12 +1,12 @@
 {
   "object": "token",
-  "id": "tokn_test_4z9f62wbr6xkp61hpln",
+  "id": "tokn_test_4z9prs98vhdkk3w7xoj",
   "livemode": false,
-  "location": "/tokens/tokn_test_4z9f62wbr6xkp61hpln",
+  "location": "/tokens/tokn_test_4z9prs98vhdkk3w7xoj",
   "used": false,
   "card": {
     "object": "card",
-    "id": "card_test_4z9f62wadvhqp345zal",
+    "id": "card_test_4z9prs97rrpg11nxcps",
     "livemode": false,
     "country": "us",
     "city": "Bangkok",
@@ -19,7 +19,7 @@
     "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
     "name": "Somchai Prasert",
     "security_code_check": true,
-    "created": "2015-03-05T08:07:19Z"
+    "created": "2015-03-06T02:11:38Z"
   },
-  "created": "2015-03-05T08:07:19Z"
+  "created": "2015-03-06T02:11:38Z"
 }

--- a/source/api/tokens/_response.json
+++ b/source/api/tokens/_response.json
@@ -1,24 +1,25 @@
 {
   "object": "token",
-  "id": "tokn_test_4xs9408a642a1htto8z",
+  "id": "tokn_test_4z9f62wbr6xkp61hpln",
   "livemode": false,
-  "location": "/tokens/tokn_test_4xs9408a642a1htto8z",
+  "location": "/tokens/tokn_test_4z9f62wbr6xkp61hpln",
   "used": false,
   "card": {
     "object": "card",
-    "id": "card_test_4xs94086bpvq56tghuo",
+    "id": "card_test_4z9f62wadvhqp345zal",
     "livemode": false,
-    "country": "th",
+    "country": "us",
     "city": "Bangkok",
     "postal_code": "10320",
-    "financing": "credit",
+    "financing": "",
     "last_digits": "4242",
     "brand": "Visa",
     "expiration_month": 10,
     "expiration_year": 2018,
-    "fingerprint": "/LCaOoTah/+As+qKsohIldZkEfew0Zq2nJKgIObRwMI=",
+    "fingerprint": "mKleiBfwp+PoJWB/ipngANuECUmRKjyxROwFW5IO7TM=",
     "name": "Somchai Prasert",
-    "created": "2014-10-20T09:41:56Z"
+    "security_code_check": true,
+    "created": "2015-03-05T08:07:19Z"
   },
-  "created": "2014-10-20T09:41:56Z"
+  "created": "2015-03-05T08:07:19Z"
 }

--- a/source/api/transactions/_response.json
+++ b/source/api/transactions/_response.json
@@ -1,8 +1,8 @@
 {
   "object": "transaction",
-  "id": "trxn_test_4xuy2z4w5vmvq4x5pfs",
-  "type": "credit",
-  "amount": 9635024,
-  "currency": "thb",
-  "created": "2014-10-27T06:58:56Z"
+  "id": "trxn_test_4z9d4abslzu19kjdc5h",
+  "type": "debit",
+  "amount": 20000,
+  "currency": "THB",
+  "created": "2015-03-05T04:37:41Z"
 }

--- a/source/api/transfers/_response.json
+++ b/source/api/transfers/_response.json
@@ -1,14 +1,6 @@
 {
-  "object": "transfer",
-  "id": "trsf_test_4y3miv1nhy0dceit4w4",
-  "livemode": false,
-  "location": "/transfers/trsf_test_4y3miv1nhy0dceit4w4",
-  "sent": false,
-  "paid": false,
-  "amount": 50000,
-  "currency": "thb",
-  "failure_code": null,
-  "failure_message": null,
-  "transaction": null,
-  "created": "2014-11-18T11:31:26Z"
+  "object": "error",
+  "location": "https://docs.omise.co/api/errors#not-found",
+  "code": "not_found",
+  "message": "transfer trsf_test_4y3i4d7lghq78ntxt8m was not found"
 }

--- a/source/object_representations/requests/01_account.sh
+++ b/source/object_representations/requests/01_account.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl https://api.omise.co/account \
+  -u %{skey}:

--- a/source/object_representations/requests/05_balance.sh
+++ b/source/object_representations/requests/05_balance.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl https://api.omise.co/balance \
+  -u %{skey}:

--- a/source/object_representations/requests/06_token.sh
+++ b/source/object_representations/requests/06_token.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+curl https://vault.omise.co/tokens \
+  -X POST \
+  -u %{pkey}: \
+  -d "card[name]=Somchai Prasert" \
+  -d "card[number]=4242424242424242" \
+  -d "card[expiration_month]=10" \
+  -d "card[expiration_year]=2018" \
+  -d "card[city]=Bangkok" \
+  -d "card[postal_code]=10320" \
+  -d "card[security_code]=123"

--- a/source/object_representations/requests/07_customer.sh
+++ b/source/object_representations/requests/07_customer.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+curl https://api.omise.co/customers \
+  -X POST \
+  -u %{skey}: \
+  -d "description=John Doe (id: 30)" \
+  -d "email=john.doe@example.com" \
+  -d "card=%{token}"

--- a/source/object_representations/requests/10_card.sh
+++ b/source/object_representations/requests/10_card.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl https://api.omise.co/customers/%{customer}/cards/%{card} \
+  -u %{skey}:

--- a/source/object_representations/requests/15_charge.sh
+++ b/source/object_representations/requests/15_charge.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+curl https://api.omise.co/charges \
+  -X POST \
+  -u %{skey}: \
+  -d "amount=100000" \
+  -d "currency=thb" \
+  -d "customer=%{customer}"

--- a/source/object_representations/requests/20_refund.sh
+++ b/source/object_representations/requests/20_refund.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+curl "https://api.omise.co/charges/%{charge}/refunds" \
+  -X POST \
+  -u %{skey}: \
+  -d "amount=20000"

--- a/source/object_representations/requests/25_transaction.sh
+++ b/source/object_representations/requests/25_transaction.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+curl https://api.omise.co/transactions/trxn_test_4z9d4abslzu19kjdc5h \
+  -X GET \
+  -u %{skey}:

--- a/source/object_representations/requests/30_transfer.sh
+++ b/source/object_representations/requests/30_transfer.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+curl https://api.omise.co/transfers/trsf_test_4y3i4d7lghq78ntxt8m \
+  -X GET \
+  -u %{skey}:


### PR DESCRIPTION
**1. Description of change**

Adds a rake task to automatically pull JSON object samples from our API

**2. Objective reason**

Keeping the data examples consistent with the actual API. Not having to update every example by hand whenever something changes

**3. Developers affected by the change**

All

**4. Impact of the change**

A rake task must be launched after building the docs:
```
rake build_objects skey="Francois' test skey" pkey="Francois' test pkey"
```

The task gives helpful output regarding problems that may arise:
```
============================Generating JSON objects=============================
                          Make sure there is no error                           
ENV['pkey']          -> Success
ENV['skey']          -> Success
account              -> Success
balance              -> Success
token                -> Success
customer             -> Success
card                 -> Success
charge               -> Success
refund               -> Success
transaction          -> Success
transfer             -> ERROR! Check source/api/transfers/_response.json
======================================DONE======================================
```

Currently, the transaction and transfer objects are built with the following commands, meaning a change of account will make them fail:
```
curl https://api.omise.co/transactions/trxn_test_4z9d4abslzu19kjdc5h \
  -X GET \
  -u %{skey}:
```
```
curl https://api.omise.co/transfers/trsf_test_4y3i4d7lghq78ntxt8m \
  -X GET \
  -u %{skey}:
```

**5. Priority of change**

Low, awaiting available balance for a transfer sample.

**6. Alternate solution (if any)**

Doing nothing.
