### PR TITLE
Corrected php sample code in retrieve section of Charge API

### DIFF
--- a/source/api/charges/retrieve/_retrieve.php
+++ b/source/api/charges/retrieve/_retrieve.php
@@ -1,3 +1,3 @@
 <?php
 
-var result = client.ChargeService.GetCharge("chrg_test_4xso2s8ivdej29pqnhz");
+$charge = OmiseCharge::retrieve("chrg_test_4xso2s8ivdej29pqnhz");


### PR DESCRIPTION
Corrected the `php sample code` in **retrieve** section of **Charge API**